### PR TITLE
refactor: access Ember Models via Store

### DIFF
--- a/packages/ember-cli-mirage/addon/ember-data.js
+++ b/packages/ember-cli-mirage/addon/ember-data.js
@@ -15,6 +15,32 @@ let DsModels, Models;
 let DsSerializers, Serializers;
 
 /**
+ * Gets application instance from global context which was set inside initializers/ember-cli-mirage
+ *
+ * @method getAppInstance
+ * @private
+ * @hide
+ * @return {Object} ApplicationInstance
+ */
+function getAppInstance() {
+  let theGlobal
+    
+  if (typeof window !== 'undefined') {
+    theGlobal = window
+  } else if (typeof global !== 'undefined') {
+    theGlobal = global
+  } else if (typeof self !== 'undefined') {
+    theGlobal = self
+  }
+
+  try {
+    return theGlobal.emberCliMirageAppInstance
+  } catch(err) {
+    throw new Error('ember-cli-mirage/ember-data | global "emberCliMirageAppInstance" could not be found: ', err)
+  }
+}
+
+/**
  * Get all ember data models under the app's namespaces
  *
  * @method getDsModels
@@ -26,6 +52,9 @@ export function getDsModels() {
   if (DsModels) {
     return DsModels;
   }
+
+  let appInstance = getAppInstance()
+  let store = appInstance.__container__.lookup('service:store')
 
   let moduleMap = requirejs.entries;
   let classicModelMatchRegex = new RegExp(`^${modulePrefix}/models/(.*)$`, 'i');
@@ -46,7 +75,7 @@ export function getDsModels() {
     if (matches && matches[1]) {
       let modelName = matches[1];
 
-      let model = require(path, null, null, true).default;
+      let model = store.modelFor(modelName);
       if (isDsModel(model)) {
         DsModels[modelName] = model;
       }

--- a/packages/ember-cli-mirage/app/initializers/ember-cli-mirage.js
+++ b/packages/ember-cli-mirage/app/initializers/ember-cli-mirage.js
@@ -16,6 +16,8 @@ const { default: makeServer } = config;
 export default {
   name: 'ember-cli-mirage',
   initialize(application) {
+    setApplicationGlobal(application)
+
     if (makeServer) {
       application.register('mirage:make-server', makeServer, {
         instantiate: false,
@@ -55,4 +57,22 @@ function _defaultEnabled(env, addonConfig) {
   let usingInTest = env === 'test';
 
   return usingInDev || usingInTest;
+}
+
+function setApplicationGlobal(application) {
+  let theGlobal
+    
+  if (typeof window !== 'undefined') {
+    theGlobal = window
+  } else if (typeof global !== 'undefined') {
+    theGlobal = global
+  } else if (typeof self !== 'undefined') {
+    theGlobal = self
+  }
+
+  try {
+    theGlobal.emberCliMirageAppInstance = application
+  } catch(err) {
+    throw new Error('ember-cli-mirage/initializers/ember-cli-mirage | could not set application global: ', err)
+  }
 }


### PR DESCRIPTION
## Refactor 

- ember-data 5.x only allows accessing Models via the Store
- This refactoring removes the following Deprecation Warning:

<img width="747" alt="Screenshot 2023-08-01 at 13 35 12" src="https://github.com/miragejs/ember-cli-mirage/assets/1423394/34e8813f-e2b1-4412-b25e-4fd06f6b6fec">
<br><br>

Instead of accessing a Model with: 
```
// ember-cli-mirage/ember-data.js

let modelName = matches[1];
let model = require(path, null, null, true).default
```
It will now be accessed with:
```
// ember-cli-mirage/ember-data.js

let modelName = matches[1];
let model = appInstance.__container__.lookup('service:store').modelFor(modelName)
```
